### PR TITLE
Respect pre-set EZA_COLORS

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -8,7 +8,7 @@ if (( ! ${+commands[eza]} )); then
   fi
 fi
 
-export EZA_COLORS='da=1;34:gm=1;34:Su=1;34'
+export EZA_COLORS="${EZA_COLORS:-da=1;34:gm=1;34:Su=1;34}"
 
 alias ls='eza --group-directories-first'
 


### PR DESCRIPTION
Changes the hardcoded `export EZA_COLORS` to use `${EZA_COLORS:-...}` so users can customize via `--cmd` in `zimrc` or set the variable before the module loads.

Example:
```zsh
zmodule exa --cmd 'export EZA_COLORS="xx=37"'
```

This follows the same pattern used by other Zim modules that respect pre-existing environment variables.